### PR TITLE
Fix runtime error within example

### DIFF
--- a/docs/rainbow-dynamic.md
+++ b/docs/rainbow-dynamic.md
@@ -55,7 +55,7 @@ board.on("ready", function() {
                 cwi = 0;
             }
 
-            for(var i = 0; i < strip.stripLength(); i++) {
+            for(var i = 0; i < strip.length; i++) {
                 showColor = colorWheel( ( cwi+i ) & 255 );
                 strip.pixel( i ).color( showColor );
             }


### PR DESCRIPTION
When setting this code up, I hit one tiny roadbump. My console reported that `strip.stripLength()` is no longer supported:

```
Error: NotImplemented: stripLength is no longer supported
```

I guessed that `strip.length` was the new prop and it seems to work.